### PR TITLE
Initial `fit_templates_fast` implementation

### DIFF
--- a/docs/src/fitting.md
+++ b/docs/src/fitting.md
@@ -69,6 +69,11 @@ This method simply minimizes the negative logarithm of the Poisson likelihood ra
 
 where ``m_i`` is bin ``i`` of the complex model and ``n_i`` is bin ``i`` of the observed Hess diagram; this can therefore be thought of as computing the maximum likelihood estimate.
 
+We also provide [`StarFormationHistories.fit_templates_fast`](@ref), which is the fastest method we offer for deriving a maximum likelihood estimate for the type of model described above.
+
+```@docs
+StarFormationHistories.fit_templates_fast
+```
 
 ### Uncertainties and Change of Variables
 


### PR DESCRIPTION
Adds `fit_templates_fast` method and documentation that finds maximum likelihood estimates for SFH coefficients similarly to `fit_templates` but utilizes a sqrt transform rather than a log transform for improved convergence speed and does not return a maximum a posteriori result like `fit_templates` does. This method is meant to be used in hierarchical models. For an example test, this method took 2 ms with keyword argument `g_abstol=1e-3` compared to ~7.5 ms for the existing `fit_templates` method.