### PR TITLE
allow matplotlib > 3.8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           python-version: '3.x'
       - run: python -m pip install --upgrade pip
-      - run: pip install 'matplotlib==3.8.*'
+      - run: pip install 'matplotlib==3.*'
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'


### PR DESCRIPTION
PyPlot.jl previously didn't support mpl 3.9, it should now