### PR TITLE
Replace @assert calls with ArgCheck.@argcheck

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["cgarling <chris.t.garling@gmail.com>"]
 version = "1.0.2"
 
 [deps]
+ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DynamicHMC = "bbc10e6e-7c05-544b-b16e-64fede858acb"
@@ -39,7 +40,8 @@ DataFramesExt = "DataFrames"
 TypedTablesExt = "TypedTables"
 
 [compat]
-Compat = "4.13" # for allequal(f, itr)
+ArgCheck = "2"
+Compat = "4.13"
 DataFrames = "1"
 DelimitedFiles = "<0.0.1, 1"
 Distributions = "0.25"
@@ -53,6 +55,7 @@ LBFGSB = "0.4"
 LineSearches = "7.2"
 LinearAlgebra = "<0.0.1, 1"
 LogDensityProblems = "1, 2"
+Logging = "<0.0.1, 1"
 LoopVectorization = "0.12"
 MCMCChains = "6, 7"
 Optim = "1.7" # Inverse Hessian estimate from BFGS
@@ -82,6 +85,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DynamicHMC = "bbc10e6e-7c05-544b-b16e-64fede858acb"
 InitialMassFunctions = "e9251ff4-c148-4db3-bf46-89407750fae0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -93,4 +97,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [targets]
-test = ["DataFrames", "DelimitedFiles", "Distributions", "Documenter", "DynamicHMC", "InitialMassFunctions", "LinearAlgebra", "MCMCChains", "QuadGK", "Random", "SafeTestsets", "StableRNGs", "StaticArrays", "StatsBase", "Test", "TypedTables"]
+test = ["DataFrames", "DelimitedFiles", "Distributions", "Documenter", "DynamicHMC", "InitialMassFunctions", "LinearAlgebra", "Logging", "MCMCChains", "QuadGK", "Random", "SafeTestsets", "StableRNGs", "StaticArrays", "StatsBase", "Test", "TypedTables"]

--- a/ext/DataFramesExt.jl
+++ b/ext/DataFramesExt.jl
@@ -1,6 +1,7 @@
 module DataFramesExt
 
 import StarFormationHistories: process_ASTs
+using ArgCheck: @argcheck
 using Printf: @sprintf
 using DataFrames: DataFrame
 using StatsBase: median, mean
@@ -8,7 +9,7 @@ using StatsBase: median, mean
 function process_ASTs(ASTs::DataFrame, inmag::Symbol, outmag::Symbol,
                       bins::AbstractVector{<:Real}, selectfunc;
                       statistic=median)
-    @assert length(bins) > 1
+    @argcheck length(bins) > 1
     !issorted(bins) && sort!(bins)
 
     completeness = Vector{Float64}(undef, length(bins)-1)

--- a/ext/TypedTablesExt.jl
+++ b/ext/TypedTablesExt.jl
@@ -1,6 +1,7 @@
 module TypedTablesExt
 
 import StarFormationHistories: process_ASTs
+using ArgCheck: @argcheck
 using Printf: @sprintf
 using TypedTables: Table
 using StatsBase: median, mean
@@ -8,7 +9,7 @@ using StatsBase: median, mean
 function process_ASTs(ASTs::Table, inmag::Symbol, outmag::Symbol,
                       bins::AbstractVector{<:Real}, selectfunc;
                       statistic=median)
-    @assert length(bins) > 1
+    @argcheck length(bins) > 1
     !issorted(bins) && sort!(bins)
 
     completeness = Vector{Float64}(undef, length(bins)-1)

--- a/src/fitting/hierarchical/fixed_amr.jl
+++ b/src/fitting/hierarchical/fixed_amr.jl
@@ -49,11 +49,11 @@ function fixed_amr(models::AbstractMatrix{S},
 
     composite = Vector{S}(undef,length(data)) # Scratch matrix for storing complex Hess model
     unique_logAge = unique(logAge)
-    @assert length(x0) == length(unique_logAge)
-    @assert size(models,1) == length(data)
-    @assert size(models,2) == length(logAge) == length(metallicities) == length(relweights)
-    @assert all(x -> x ≥ 0, relweights) # All relative weights must be \ge 0
-    @assert relweightsmin >= 0 # By definition relweightsmin must be greater than or equal to 0
+    @argcheck length(x0) == length(unique_logAge)
+    @argcheck size(models,1) == length(data)
+    @argcheck size(models,2) == length(logAge) == length(metallicities) == length(relweights)
+    @argcheck all(x -> x ≥ 0, relweights) # All relative weights must be \ge 0
+    @argcheck relweightsmin >= 0 # By definition relweightsmin must be greater than or equal to 0
     
     # Identify which of the provided models are significant enough
     # to be included in the fitting on the basis of the provided `relweightsmin`.
@@ -104,7 +104,7 @@ function fixed_amr(models::AbstractMatrix{S},
         logL = loglikelihood(composite, data) # Need to do this before ∇loglikelihood! because it will overwrite composite
         logL += sum(xvec) # This is the Jacobian correction
         if (F != nothing) & (G != nothing) # Optim.optimize wants objective and gradient
-            @assert axes(G) == axes(x)
+            @argcheck axes(G) == axes(x)
             # Calculate the ∇loglikelihood with respect to model coefficients
             ∇loglikelihood!(fullG, composite, models, data)
             # Now need to do the transformation to the per-logage `x` variables
@@ -129,7 +129,7 @@ function fixed_amr(models::AbstractMatrix{S},
         composite!( composite, coeffs, models )
         logL = loglikelihood(composite, data) # Need to do this before ∇loglikelihood! because it will overwrite composite
         if (F != nothing) & (G != nothing) # Optim.optimize wants objective and gradient
-            @assert axes(G) == axes(x)
+            @argcheck axes(G) == axes(x)
             # Calculate the ∇loglikelihood with respect to model coefficients
             ∇loglikelihood!(fullG, composite, models, data)
             # Now need to do the transformation to the per-logage `x` variables
@@ -220,7 +220,7 @@ which correspond to `relweights[2,3,4] = [ 0.2284109622221623, 0.498895408884822
 function truncate_relweights(relweightsmin::Number,
                              relweights::AbstractVector{<:Number},
                              logAge::AbstractVector{<:Number})
-    @assert length(relweights) == length(logAge)
+    @argcheck length(relweights) == length(logAge)
     relweightsmin == 0 && return collect(eachindex(relweights, logAge)) # short circuit for relweightsmin = 0
     keep_idx = Vector{Int}[] # Vector of vectors of integer indices
     for la in unique(logAge)

--- a/src/fitting/hierarchical/generic_fitting.jl
+++ b/src/fitting/hierarchical/generic_fitting.jl
@@ -178,7 +178,7 @@ function LogDensityProblems.logdensity_and_gradient(problem::HierarchicalOptimiz
     end
     
     # Write gradient from G2 into G for free parameters
-    @assert axes(G) == axes(xvec)
+    @argcheck axes(G) == axes(xvec)
     for i in firstindex(G):Nbins; G[i] = G2[i]; end
     free_count = 1
     for i in 1:length(free)
@@ -249,9 +249,9 @@ function fit_sfh(MH_model0::AbstractMetallicityModel{T}, disp_model0::AbstractDi
 
     unique_logAge = unique(logAge)
     Nbins = length(x0) # Number of unique logAge bins
-    @assert length(x0) == length(unique_logAge)
-    @assert size(models, 1) == length(data)
-    @assert size(models, 2) == length(logAge) == length(metallicities)
+    @argcheck length(x0) == length(unique_logAge) "length(x0) != length(unique(logAge))"
+    @argcheck size(models, 1) == length(data)
+    @argcheck size(models, 2) == length(logAge) == length(metallicities)
     # Perform logarithmic transformation on the provided x0 (stellar mass coefficients)
     x0 = map(log, x0) # Does not modify x0 in place
     # Perform logarithmic transformation on MZR and dispersion parameters
@@ -646,7 +646,7 @@ end
 #                      rng::AbstractRNG=default_rng()) where {S <: Number}
 
 #     Nthreads = Threads.nthreads()
-#     @assert Nsteps ≥ Nthreads "`tsample_sfh` requires you request at least as many samples as available threads (`Nsteps > Threads.nthreads`)."
+#     @argcheck Nsteps ≥ Nthreads "`tsample_sfh` requires you request at least as many samples as available threads (`Nsteps > Threads.nthreads`)."
 #     # Will use MLE for best-fit values, MAP for invH
 #     MAP, MLE = bfgs_result.map, bfgs_result.mle
 #     # Best-fit free parameter values from optimization in transformed fitting variables
@@ -739,7 +739,7 @@ end
 #                      rng::AbstractRNG=default_rng()) where {S <: Number}
 
 #     Nthreads = Threads.nthreads()
-#     @assert Nsteps ≥ Nthreads "`tsample_sfh` requires you request at least as many samples as available threads (`Nsteps > Threads.nthreads`)."
+#     @argcheck Nsteps ≥ Nthreads "`tsample_sfh` requires you request at least as many samples as available threads (`Nsteps > Threads.nthreads`)."
 #     # Will use MLE for best-fit values, MAP for invH
 #     MAP, MLE = bfgs_result.map, bfgs_result.mle
 #     # Best-fit free parameter values from optimization in transformed fitting variables

--- a/src/fitting/hierarchical/mzr.jl
+++ b/src/fitting/hierarchical/mzr.jl
@@ -52,9 +52,9 @@ function calculate_coeffs(mzr_model::AbstractMZR{T}, disp_model::AbstractDispers
                           logAge::AbstractVector{<:Number},
                           metallicities::AbstractVector{<:Number}) where {T, U}
     unique_logAge = unique(logAge)
-    @assert(length(mstars) == length(unique_logAge),
-            "Length of `mstars` must be the same as `unique_logAge`.")
-    @assert length(logAge) == length(metallicities)
+    @argcheck(length(mstars) == length(unique_logAge),
+            "Length of `mstars` must be the same as `unique(logAge)`.")
+    @argcheck length(logAge) == length(metallicities)
     S = promote_type(eltype(mstars), eltype(logAge), eltype(metallicities), T, U)
 
     # To calculate cumulative stellar mass, we need unique_logAge sorted in reverse order
@@ -90,7 +90,7 @@ function fg!(F, G, MHmodel0::AbstractMZR{T}, dispmodel0::AbstractDispersionModel
              logAge::AbstractVector{<:Number},
              metallicities::AbstractVector{<:Number}) where {T, U}
 
-    @assert axes(data) == axes(composite)
+    @argcheck axes(data) == axes(composite)
     S = promote_type(eltype(variables), eltype(eltype(models)), eltype(eltype(data)),
                      eltype(composite), eltype(logAge), eltype(metallicities),
                      T, U)
@@ -123,7 +123,7 @@ function fg!(F, G, MHmodel0::AbstractMZR{T}, dispmodel0::AbstractDispersionModel
 
     if !isnothing(G) # Optim.optimize wants gradient -- update G in place
         Base.require_one_based_indexing(G)
-        @assert axes(G) == axes(variables)
+        @argcheck axes(G) == axes(variables)
         # Calculate the ∇loglikelihood with respect to model coefficients
         fullG = Vector{eltype(G)}(undef, length(coeffs))
         ∇loglikelihood!(fullG, composite, models, data)

--- a/src/fitting/hierarchical/transformations.jl
+++ b/src/fitting/hierarchical/transformations.jl
@@ -62,7 +62,7 @@ function exptransform_samples!(samples::AbstractVecOrMat{<:Number},
     Base.require_one_based_indexing(samples, μ, transformations, free)
     # length of transformations and free are equal to the number of
     # metallicity model parameters plus dispersion model parameters
-    @assert length(transformations) == length(free)
+    @argcheck length(transformations) == length(free)
     # size(samples) = (nvariables, nsamples)
     Nsamples = size(samples, 2)
     Nbins = size(samples, 1) - length(free) # Number of stellar mass coefficients / SFRs

--- a/src/fitting/utilities.jl
+++ b/src/fitting/utilities.jl
@@ -30,11 +30,11 @@ julia> sum(x0)
 """
 function construct_x0(logAge::AbstractVector{T}, T_max::Number;
                       normalize_value::Number=one(T)) where T <: Number
-    min_log, max_log = extrema(logAge)
+    @argcheck log10(T_max) + 9 > maximum(logAge)
+    min_logAge = minimum(logAge)
     max_logAge = log10(T_max) + 9 # T_max in units of Gyr
-    @assert max_logAge > max_log # max_logAge must be greater than maximum(logAge)
     unique_logAge = vcat(sort!(unique(logAge)), max_logAge)
-    sfr = normalize_value / (exp10(max_logAge) - exp10(min_log)) # Average SFR / yr
+    sfr = normalize_value / (exp10(max_logAge) - exp10(min_logAge)) # Average SFR / yr
     num_ages = [count(logAge .== la) for la in unique_logAge] # number of entries per unique
     dt = [exp10(unique_logAge[i+1]) - exp10(unique_logAge[i]) for i in 1:length(unique_logAge)-1]
     result = similar(logAge)
@@ -74,9 +74,9 @@ Calculates cumulative star formation history, star formation rates, and mean met
  - `mean_MH::Vector` gives the stellar-mass-weighted mean metallicity of the stellar population as a function of `unique_logAge`. 
 """
 function calculate_cum_sfr(coeffs::AbstractVector, logAge::AbstractVector, MH::AbstractVector, T_max::Number; normalize_value=1, sorted::Bool=false)
-    @assert axes(coeffs) == axes(logAge) == axes(MH)
+    @argcheck axes(coeffs) == axes(logAge) == axes(MH)
+    @argcheck log10(T_max) + 9 > maximum(logAge)
     max_logAge = log10(T_max) + 9 # T_max in units of Gyr
-    @assert max_logAge > maximum(logAge)
     coeffs = coeffs .* normalize_value # Transform the coefficients to proper stellar masses
     mstar_total = sum(coeffs) # Calculate the total stellar mass of the model
     # Calculate the stellar mass per time bin by summing over the different MH at each logAge

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -52,7 +52,7 @@ ingest_mags(mini_vec, mags) = throw(ArgumentError("There is no `ingest_mags` met
 Takes `mini_vec` and `mags` and ensures that `mini_vec` is sorted (sometimes in PARSEC isochrones they are not) and calls `Interpolations.deduplicate_knots!` on `mini_vec` to ensure there are no repeat entries. Arguments must satisfy `length(mini_vec) == length(mags)`. 
 """
 function sort_ingested(mini_vec::AbstractVector, mags::AbstractVector)
-    @assert axes(mini_vec) == axes(mags)
+    @argcheck axes(mini_vec) == axes(mags)
     idx = sortperm(mini_vec)
     if idx != eachindex(mini_vec)
         mini_vec = mini_vec[idx]
@@ -92,7 +92,7 @@ julia> mass_limits([0.05,0.1,0.2,0.3], [[4.0,3.0],[3.0,2.0],[2.0,1.0],[1.0,0.0]]
 function mass_limits(mini_vec::AbstractVector{<:Number}, mags::AbstractVector{T},
                      mag_names::AbstractVector{String}, mag_lim::Number,
                      mag_lim_name::String) where T <: AbstractVector{<:Number}
-    @assert axes(mini_vec) == axes(mags) 
+    @argcheck axes(mini_vec) == axes(mags) 
     mmin, mmax = extrema(mini_vec)
     # Update mmin respecing `mag_lim`, if provided.
     if !isfinite(mag_lim)
@@ -164,7 +164,7 @@ struct RandomBinaryPairs{T <: Real} <: AbstractBinaryModel
     # Outer-only constructor to guarantee support
     # See https://docs.julialang.org/en/v1/manual/constructors/#Outer-only-constructors
     function RandomBinaryPairs(fraction::T) where T <: Real
-        @assert (fraction >= zero(T)) && (fraction <= one(T))
+        @argcheck (fraction >= zero(T)) && (fraction <= one(T))
         new{T}(fraction)
     end
 end
@@ -199,7 +199,8 @@ struct BinaryMassRatio{T <: Real, S <: Distribution{Univariate, Continuous}} <: 
     # See https://docs.julialang.org/en/v1/manual/constructors/#Outer-only-constructors
     function BinaryMassRatio(fraction::T, qdist::S=Uniform(0.1, 1.0)) where {T <: Real, S <: Distribution{Univariate, Continuous}}
         V = eltype(qdist)
-        @assert (fraction >= zero(T)) && (fraction <= one(T)) && (minimum(qdist) >= zero(V)) && (maximum(qdist) <= one(V))
+        @argcheck (fraction >= zero(T)) && (fraction <= one(T))
+        @argcheck (minimum(qdist) >= zero(V)) && (maximum(qdist) <= one(V))
         new{T,S}(fraction, qdist)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ import MCMCChains
 import DynamicHMC
 # import Optim
 using Test, SafeTestsets
+using Logging: with_logger, ConsoleLogger, Error
 
 # Run doctests first
 import Documenter: DocMeta, doctest
@@ -540,7 +541,10 @@ const rtols = (1e-3, 1e-7) # Relative tolerance levels to use for the above floa
     @testset "utilities" begin
         # Artifical star tests use extensions, requires Julia >= 1.9
         if VERSION >= v"1.9"
-            @safetestset "process_ASTs" include("utilities/process_ASTs_test.jl")
+            # We are intentionally causing some warnings, they are not significant
+            with_logger(ConsoleLogger(Error)) do
+                @safetestset "process_ASTs" include("utilities/process_ASTs_test.jl")
+            end
         end
 
         @testset "mdf_amr" begin


### PR DESCRIPTION
Fixes #57. Also adds Logging as [extras] dependency for use in testing to suppress warnings from `process_ASTs` tests which we are triggering on purpose and so should not be passed through to the output